### PR TITLE
fix(parse): fix loader order

### DIFF
--- a/.github/actions/parse/action.yml
+++ b/.github/actions/parse/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Parse the pack.toml
       id: parse
       run: |
-        loaders=("fabric" "forge" "quilt" "neoforge")
+        loaders=("fabric" "quilt" "neoforge" "forge")
         for loader in "${loaders[@]}"; do
           if [[ $(<"${{ inputs.pack-file }}") == *"$loader ="* ]]; then
             LOADER="$loader" && break


### PR DESCRIPTION
Fixes the loader order to prioritize neoforge over forge so that forge isn't selected as the loader even though neoforge is the one being used